### PR TITLE
Adding pickup and delivery to alllowed types on activity

### DIFF
--- a/lib/graphhopper/models/activity.rb
+++ b/lib/graphhopper/models/activity.rb
@@ -77,7 +77,7 @@ module GraphHopper
 
     # Custom attribute writer method checking allowed values (enum).
     def type=(type)
-      allowed_values = ["start", "end", "service", "pickupShipment", "deliverShipment"]
+      allowed_values = ["start", "end", "service", "pickupShipment", "deliverShipment", "pickup", "delivery"]
       if type && !allowed_values.include?(type)
         fail "invalid value for 'type', must be one of #{allowed_values}"
       end


### PR DESCRIPTION
GraphHopper gem does not contain the 'delivery' and 'pickup' types for an activity (service or shipment).

This is the bug opened in the official repository: https://github.com/graphhopper/directions-api-clients-route-optimization/issues/5