### PR TITLE
[LIEF-12747] Gzip body in Graphhopper requests

### DIFF
--- a/lib/graphhopper/api/vrp_api.rb
+++ b/lib/graphhopper/api/vrp_api.rb
@@ -50,6 +50,8 @@ module GraphHopper
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
+      # HTTP header 'Content-Type'
+      header_params['Content-Encoding'] = 'gzip'
 
       # form parameters
       form_params = {}

--- a/lib/graphhopper/api/vrp_api.rb
+++ b/lib/graphhopper/api/vrp_api.rb
@@ -6,6 +6,7 @@ module GraphHopper
 
     def initialize(api_client = ApiClient.default)
       @api_client = api_client
+      @api_client.use_compression = true
     end
 
     # Solves vehicle routing problems
@@ -50,8 +51,8 @@ module GraphHopper
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
-      # HTTP header 'Content-Type'
-      header_params['Content-Encoding'] = 'gzip'
+      # HTTP header 'Content-Encoding'
+      header_params['Content-Encoding'] = @api_client.select_header_content_encoding
 
       # form parameters
       form_params = {}

--- a/lib/graphhopper/api_client.rb
+++ b/lib/graphhopper/api_client.rb
@@ -16,6 +16,8 @@ module GraphHopper
     # @return [Hash]
     attr_accessor :default_headers
 
+    attr_accessor :use_compression
+
     # Initializes the ApiClient
     # @option config [GemConfiguration] GemConfiguration for initializing the object,
     # default to GemConfiguration.default
@@ -26,6 +28,7 @@ module GraphHopper
         'Content-Type' => "application/json",
         'User-Agent' => @user_agent
       }
+      @use_compression = false
     end
 
     def self.default
@@ -330,6 +333,14 @@ module GraphHopper
       # use JSON when present, otherwise use the first one
       json_content_type = content_types.find { |s| json_mime?(s) }
       return json_content_type || content_types.first
+    end
+
+    # Return Content-Encoding header based on use_compression
+    # @return [String] the Content-Encoding header
+    def select_header_content_encoding
+      return unless use_compression
+
+      'gzip'
     end
 
     # Convert object (array, hash, object, etc) to JSON string.

--- a/lib/graphhopper/api_client.rb
+++ b/lib/graphhopper/api_client.rb
@@ -282,7 +282,7 @@ module GraphHopper
         data = nil
       end
 
-      if data && header_params['Content-Encoding'] == 'gzip'
+      if data && use_compression
         data = Zlib.gzip(data)
       end
 

--- a/lib/graphhopper/api_client.rb
+++ b/lib/graphhopper/api_client.rb
@@ -4,6 +4,7 @@ require 'logger'
 require 'tempfile'
 require 'typhoeus'
 require 'uri'
+require "zlib"
 
 module GraphHopper
   class ApiClient
@@ -23,6 +24,7 @@ module GraphHopper
       @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
       @default_headers = {
         'Content-Type' => "application/json",
+        'Content-Encoding' => "gzip",
         'User-Agent' => @user_agent
       }
     end
@@ -277,7 +279,8 @@ module GraphHopper
       else
         data = nil
       end
-      data
+
+      Zlib::Deflate.deflate(data)
     end
 
     # Update hearder and query params based on authentication settings.

--- a/lib/graphhopper/api_client.rb
+++ b/lib/graphhopper/api_client.rb
@@ -24,7 +24,6 @@ module GraphHopper
       @user_agent = "Swagger-Codegen/#{VERSION}/ruby"
       @default_headers = {
         'Content-Type' => "application/json",
-        'Content-Encoding' => "gzip",
         'User-Agent' => @user_agent
       }
     end
@@ -280,7 +279,7 @@ module GraphHopper
         data = nil
       end
 
-      if data
+      if data && header_params['Content-Encoding'] == 'gzip'
         data = Zlib.gzip(data)
       end
 

--- a/lib/graphhopper/api_client.rb
+++ b/lib/graphhopper/api_client.rb
@@ -280,7 +280,11 @@ module GraphHopper
         data = nil
       end
 
-      Zlib::Deflate.deflate(data)
+      if data
+        data = Zlib.gzip(data)
+      end
+
+      data
     end
 
     # Update hearder and query params based on authentication settings.


### PR DESCRIPTION
```
Bandwidth reduction
If you create your own client, make sure it supports http/2 and gzipped responses for best speed.

If you use the Matrix or Route Optimization API and want to solve large problems, we recommend you to reduce bandwidth by compressing your POST request and specifying the header as follows: Content-Encoding: gzip.
```

https://docs.graphhopper.com/#section/Explore-our-APIs/API-Clients